### PR TITLE
WIP: Larger packets

### DIFF
--- a/lib/telemetry_metrics_statsd.ex
+++ b/lib/telemetry_metrics_statsd.ex
@@ -393,7 +393,7 @@ defmodule TelemetryMetricsStatsd do
   @spec udp_error(pid(), reason :: term) :: :ok
   def udp_error(udp, reason) do
     Logger.error("Failed to publish metrics over UDP: #{inspect(reason)}")
-    UDP.stop(udp, reason)
+    UDP.close(udp)
   end
 
   @impl true

--- a/lib/telemetry_metrics_statsd.ex
+++ b/lib/telemetry_metrics_statsd.ex
@@ -401,7 +401,10 @@ defmodule TelemetryMetricsStatsd do
     Process.flag(:trap_exit, true)
     metrics = Map.fetch!(options, :metrics)
 
-    default_udp_config = %{mtu: options.mtu, max_report_interval_ms: options.max_report_interval_ms}
+    default_udp_config = %{
+      mtu: options.mtu,
+      max_report_interval_ms: options.max_report_interval_ms
+    }
 
     udp_config = Map.merge(configure_host_resolution(options), default_udp_config)
 
@@ -428,8 +431,6 @@ defmodule TelemetryMetricsStatsd do
        host_resolution_interval: options.host_resolution_interval
      }}
   end
-
-
 
   @impl true
   def handle_call(:get_pool_id, _from, %{pool_id: pool_id} = state) do

--- a/lib/telemetry_metrics_statsd/event_handler.ex
+++ b/lib/telemetry_metrics_statsd/event_handler.ex
@@ -128,14 +128,14 @@ defmodule TelemetryMetricsStatsd.EventHandler do
   @spec publish_metrics(pid(), :ets.tid(), [binary()]) :: :ok
   defp publish_metrics(reporter, pool_id, packets) do
     case TelemetryMetricsStatsd.get_udp(pool_id) do
-      {:ok, udp} ->
+      {:ok, pid} ->
         Enum.reduce_while(packets, :cont, fn packet, :cont ->
-          case UDP.send(udp, packet) do
+          case UDP.send(pid, packet) do
             :ok ->
               {:cont, :cont}
 
             {:error, reason} ->
-              TelemetryMetricsStatsd.udp_error(reporter, udp, reason)
+              TelemetryMetricsStatsd.udp_error(reporter, pid, reason)
               {:halt, :halt}
           end
         end)

--- a/lib/telemetry_metrics_statsd/options.ex
+++ b/lib/telemetry_metrics_statsd/options.ex
@@ -60,6 +60,12 @@ defmodule TelemetryMetricsStatsd.Options do
       doc:
         "Maximum Transmission Unit of the link between your application and the StastD server in bytes. " <>
           "If this value is greater than the actual MTU of the link, UDP packets with published metrics will be dropped."
+    ],
+    max_report_interval_ms: [
+      type: :non_neg_integer,
+      default: 1000,
+      doc:
+        "maximum time to keep buffering metrics"
     ]
   ]
 

--- a/lib/telemetry_metrics_statsd/options.ex
+++ b/lib/telemetry_metrics_statsd/options.ex
@@ -64,8 +64,7 @@ defmodule TelemetryMetricsStatsd.Options do
     max_report_interval_ms: [
       type: :non_neg_integer,
       default: 1000,
-      doc:
-        "maximum time to keep buffering metrics"
+      doc: "maximum time to keep buffering metrics"
     ]
   ]
 

--- a/lib/telemetry_metrics_statsd/packet.ex
+++ b/lib/telemetry_metrics_statsd/packet.ex
@@ -1,6 +1,69 @@
 defmodule TelemetryMetricsStatsd.Packet do
   @moduledoc false
 
+  require Logger
+  alias __MODULE__
+
+  @type t :: %__MODULE__{
+          max_bytes: integer(),
+          max_age_micro: integer(),
+          send_fun: function(),
+          data: iodata(),
+          bytes: integer(),
+          birth_micro: integer()
+        }
+
+  defstruct max_bytes: nil,
+            max_age_micro: nil,
+            send_fun: nil,
+            data: [],
+            bytes: 0,
+            birth_micro: nil
+
+  @spec new(max_bytes :: integer(), max_age_micro :: integer(), send_fun :: function()) :: Packet.t()
+  def new(max_bytes, max_age_micro, send_fun) do
+    do_new(max_bytes, max_age_micro, send_fun)
+  end
+
+  @spec get_timeout(Packet.t()) :: integer()
+  def get_timeout(%Packet{max_age_micro: max_age_micro, birth_micro: birth_micro}) do
+    case max_age_micro - (now() - birth_micro) do
+      t when t < 1000 -> 0
+      t -> div(t, 1000)
+    end
+  end
+
+  @spec maybe_send(Packet.t(), iodata()) :: Packet.t()
+  def maybe_send(packet, line) when is_list(line) do
+    maybe_send(packet, IO.iodata_to_binary(line))
+  end
+
+  def maybe_send(packet, "") do
+    maybe_send(packet)
+  end
+
+  def maybe_send(%Packet{max_bytes: max_bytes} = packet, line) when byte_size(line) > max_bytes do
+    Logger.error("discarded due to packet size overflow:\nmetric=#{inspect(line)}")
+    maybe_send(packet)
+  end
+
+  def maybe_send(%Packet{bytes: bytes, data: data, max_bytes: max_bytes} = packet, line) when is_binary(line) do
+    new_bytes = concatenated_size(bytes, byte_size(line))
+    case new_bytes > max_bytes do
+      true ->
+        new_packet = flush_send(packet)
+        maybe_send(new_packet, line)
+      false ->
+        maybe_send(%Packet{packet | data: concatenate(data, line), bytes: new_bytes}, line)
+    end
+  end
+
+  @spec flush_send(Packet.t()) :: Packet.t()
+  def flush_send(%Packet{data: data, bytes: bytes, max_bytes: max_bytes, max_age_micro: max_age_micro, send_fun: send_fun}) do
+    bytes > 0 && send_fun.(data)
+    do_new(max_bytes, max_age_micro, send_fun)
+  end
+
   @spec build_packets([binary()], size :: non_neg_integer(), joiner :: binary()) :: [binary()]
   def build_packets(binaries, max_size, joiner)
       when is_integer(max_size) and max_size > 0 and is_binary(joiner) do
@@ -50,5 +113,25 @@ defmodule TelemetryMetricsStatsd.Packet do
         packet | acc
       ])
     end
+  end
+
+  defp maybe_send(packet) do
+    case get_timeout(packet) == 0 do
+      true  -> flush_send(packet)
+      false -> packet
+    end
+  end
+
+
+  defp concatenated_size(0, new_line_bytes), do: new_line_bytes
+  defp concatenated_size(bytes, new_line_bytes), do: bytes + new_line_bytes + 1
+
+  defp concatenate([], line), do: [line]
+  defp concatenate(acc_lines, line), do: [acc_lines, ?\n, line]
+
+  defp now(), do: System.system_time(:microsecond)
+
+  defp do_new(max_bytes, max_age_micro, send_fun) do
+    %Packet{max_bytes: max_bytes, max_age_micro: max_age_micro, send_fun: send_fun, birth_micro: now()}
   end
 end

--- a/lib/telemetry_metrics_statsd/packet.ex
+++ b/lib/telemetry_metrics_statsd/packet.ex
@@ -54,7 +54,7 @@ defmodule TelemetryMetricsStatsd.Packet do
         new_packet = flush_send(packet)
         maybe_send(new_packet, line)
       false ->
-        maybe_send(%Packet{packet | data: concatenate(data, line), bytes: new_bytes}, line)
+        maybe_send(%Packet{packet | data: concatenate(data, line), bytes: new_bytes})
     end
   end
 

--- a/lib/telemetry_metrics_statsd/pool.ex
+++ b/lib/telemetry_metrics_statsd/pool.ex
@@ -1,0 +1,43 @@
+defmodule TelemetryMetricsStatsd.Pool do
+  @moduledoc false
+
+  @pool __MODULE__
+
+  alias TelemetryMetricsStatsd.UDP
+
+  def new(pool_size, udp_config) do
+    options = [
+      workers: pool_size,
+      worker: {UDP, udp_config}
+    ]
+
+    pool_id =
+      :rand.bytes(10)
+      |> Base.encode16()
+      |> String.to_atom()
+
+    case :wpool.start_sup_pool(pool_id, options) do
+      {:ok, _pid} -> {:ok, pool_id}
+      other -> other
+    end
+  end
+
+  def send(pool_id, packet) do
+    :wpool.cast(pool_id, {:send, packet})
+  end
+
+  def get_udp(pool_id) do
+    :wpool_pool.random_worker(pool_id)
+  end
+
+  def get_workers(pool_id) do
+    :wpool.get_workers(pool_id)
+  end
+
+  def update(pool_id, new_host, new_port) do
+    get_workers(pool_id)
+    |> Enum.each(fn name ->
+      UDP.update(name, new_host, new_port)
+    end)
+  end
+end

--- a/lib/telemetry_metrics_statsd/pool.ex
+++ b/lib/telemetry_metrics_statsd/pool.ex
@@ -1,8 +1,6 @@
 defmodule TelemetryMetricsStatsd.Pool do
   @moduledoc false
 
-  @pool __MODULE__
-
   alias TelemetryMetricsStatsd.UDP
 
   def new(pool_size, udp_config) do
@@ -39,5 +37,9 @@ defmodule TelemetryMetricsStatsd.Pool do
     |> Enum.each(fn name ->
       UDP.update(name, new_host, new_port)
     end)
+  end
+
+  def stop(pool_id) do
+    :wpool.stop_sup_pool(pool_id)
   end
 end

--- a/lib/telemetry_metrics_statsd/udp.ex
+++ b/lib/telemetry_metrics_statsd/udp.ex
@@ -2,6 +2,7 @@ defmodule TelemetryMetricsStatsd.UDP do
   @moduledoc false
 
   use GenServer
+  require Logger
 
   defstruct [:host, :port, :socket]
 
@@ -20,7 +21,7 @@ defmodule TelemetryMetricsStatsd.UDP do
     GenServer.start_link(__MODULE__, options)
   end
 
-  @spec send(pid, iodata) :: :ok | {:error, term}
+  @spec send(GenServer.name(), iodata) :: :ok | {:error, term}
   def send(pid, data) do
     GenServer.call(pid, {:send, data})
   end
@@ -33,6 +34,9 @@ defmodule TelemetryMetricsStatsd.UDP do
     GenServer.call(pid, :close)
   end
 
+  def stop(pid, reason) do
+    GenServer.stop(pid, reason)
+  end
 
   @impl true
   def init(config) do

--- a/lib/telemetry_metrics_statsd/udp.ex
+++ b/lib/telemetry_metrics_statsd/udp.ex
@@ -125,9 +125,9 @@ defmodule TelemetryMetricsStatsd.UDP do
       :ok ->
         :ok
 
-      {:error, reason} = error ->
+      {:error, reason} ->
         TelemetryMetricsStatsd.udp_error(socket_owner, reason)
-        error
+        :ok
     end
   end
 end

--- a/lib/telemetry_metrics_statsd/udp.ex
+++ b/lib/telemetry_metrics_statsd/udp.ex
@@ -65,7 +65,10 @@ defmodule TelemetryMetricsStatsd.UDP do
   end
 
   @impl true
-  def handle_cast({:update, new_host, new_port}, %__MODULE__{socket: socket, packet: packet} = state) do
+  def handle_cast(
+        {:update, new_host, new_port},
+        %__MODULE__{socket: socket, packet: packet} = state
+      ) do
     new_packet = %Packet{packet | send_fun: make_send_fun(self(), socket, new_host, new_port)}
     noreply(%__MODULE__{state | host: new_host, port: new_port, packet: new_packet})
   end

--- a/mix.exs
+++ b/mix.exs
@@ -41,6 +41,7 @@ defmodule TelemetryMetricsStatsd.MixProject do
       {:telemetry, "~> 0.4 or ~> 1.0"},
       {:telemetry_metrics, "~> 0.6"},
       {:nimble_options, "~> 0.4"},
+      {:worker_pool, "~> 6.0"},
       {:stream_data, "~> 0.4", only: :test},
       {:dialyxir, "~> 0.5", only: :test, runtime: false},
       {:ex_doc, "~> 0.19", only: :docs},

--- a/mix.lock
+++ b/mix.lock
@@ -24,4 +24,5 @@
   "telemetry": {:hex, :telemetry, "1.0.0", "0f453a102cdf13d506b7c0ab158324c337c41f1cc7548f0bc0e130bbf0ae9452", [:rebar3], [], "hexpm", "73bc09fa59b4a0284efb4624335583c528e07ec9ae76aca96ea0673850aec57a"},
   "telemetry_metrics": {:hex, :telemetry_metrics, "0.6.1", "315d9163a1d4660aedc3fee73f33f1d355dcc76c5c3ab3d59e76e3edf80eef1f", [:mix], [{:telemetry, "~> 0.4 or ~> 1.0", [hex: :telemetry, repo: "hexpm", optional: false]}], "hexpm", "7be9e0871c41732c233be71e4be11b96e56177bf15dde64a8ac9ce72ac9834c6"},
   "unicode_util_compat": {:hex, :unicode_util_compat, "0.4.1", "d869e4c68901dd9531385bb0c8c40444ebf624e60b6962d95952775cac5e90cd", [:rebar3], [], "hexpm"},
+  "worker_pool": {:hex, :worker_pool, "6.0.1", "ca262c2dfb3b4af661b206c82065d86f83922b7227508aa6e0bc34d3e5ae5135", [:rebar3], [], "hexpm", "772e12ccb26909ea7f804b52e86e733df66bb8150f683b591b0a762196494c74"},
 }

--- a/test/telemetry_metrics_statsd_test.exs
+++ b/test/telemetry_metrics_statsd_test.exs
@@ -334,7 +334,7 @@ defmodule TelemetryMetricsStatsdTest do
       udp = Process.whereis(Pool.get_udp(pool_id))
 
       assert capture_log(fn ->
-               TelemetryMetricsStatsd.udp_error(reporter, udp, :closed)
+               TelemetryMetricsStatsd.udp_error(udp, :closed)
                # errors.
                eventually(fn ->
                  Process.whereis(Pool.get_udp(pool_id)) != udp
@@ -348,7 +348,7 @@ defmodule TelemetryMetricsStatsdTest do
       pool_id = TelemetryMetricsStatsd.get_pool_id(reporter)
       udp = Process.whereis(Pool.get_udp(pool_id))
 
-      TelemetryMetricsStatsd.udp_error(reporter, udp, :closed)
+      TelemetryMetricsStatsd.udp_error(udp, :closed)
 
       assert eventually(fn -> Process.whereis(Pool.get_udp(pool_id)) != udp end)
     end
@@ -359,7 +359,7 @@ defmodule TelemetryMetricsStatsdTest do
       pool_id = TelemetryMetricsStatsd.get_pool_id(reporter)
       udp = Process.whereis(Pool.get_udp(pool_id))
 
-      TelemetryMetricsStatsd.udp_error(reporter, udp, :closed)
+      TelemetryMetricsStatsd.udp_error(udp, :closed)
 
       eventually(fn -> Process.whereis(Pool.get_udp(pool_id)) != udp end)
 

--- a/test/telemetry_metrics_statsd_test.exs
+++ b/test/telemetry_metrics_statsd_test.exs
@@ -356,10 +356,11 @@ defmodule TelemetryMetricsStatsdTest do
       reporter = start_reporter(metrics: [], pool_size: 1)
       pool_id = TelemetryMetricsStatsd.get_pool_id(reporter)
       udp = Process.whereis(Pool.get_udp(pool_id))
+      socket = udp_socket(udp)
 
       TelemetryMetricsStatsd.udp_error(udp, :closed)
 
-      assert eventually(fn -> Process.whereis(Pool.get_udp(pool_id)) != udp end)
+      assert eventually(fn -> socket != udp_socket(udp) end)
     end
 
     @tag :capture_log
@@ -367,12 +368,13 @@ defmodule TelemetryMetricsStatsdTest do
       reporter = start_reporter(metrics: [], pool_size: 1)
       pool_id = TelemetryMetricsStatsd.get_pool_id(reporter)
       udp = Process.whereis(Pool.get_udp(pool_id))
+      socket = udp_socket(udp)
 
       TelemetryMetricsStatsd.udp_error(udp, :closed)
 
-      eventually(fn -> Process.whereis(Pool.get_udp(pool_id)) != udp end)
+      eventually(fn -> socket != udp_socket(udp) end)
 
-      eventually(fn -> Process.alive?(udp) == false end)
+      eventually(fn -> nil == Port.info(socket) end)
     end
   end
 
@@ -676,5 +678,9 @@ defmodule TelemetryMetricsStatsdTest do
 
   defp udp_host(pid) do
     get_state(pid).host
+  end
+
+  defp udp_socket(pid) do
+    get_state(pid).socket
   end
 end


### PR DESCRIPTION
- [x] Change `UDP` from a struct to a GenServer
- [x] Replace custom :ets-based worker pool with [worker_pool](https://github.com/inaka/worker_pool/)
  - Note: I'm not really happy with the solution I landed on for creating multiple concurrent worker pools.
- [x] Implement packet buffering, with configurable number of bytes (e.g. for UDP; base it off of MTU minus the statsd-related header. For UDS; 8192 bytes is recommended. See [here](https://docs.datadoghq.com/developers/dogstatsd/high_throughput/#ensure-proper-packet-sizes) for a good guide about tuning for high-throughput metrics)
  - Currently, the tests use a `assert_reported/2` helper function which calls `:gen_udp.recv`. This will likely have to change to accommodate larger packets containing many metrics.
- [ ] Document packet buffering
- [ ] Expose choice of worker selection (I think hash_worker will work well here)
  - In particular, with `hash_worker`, it becomes possible to do client-side aggregation of metrics. For example, if the `foo.bar` counter is incremented once 10,000 times, all those increments go to the same worker, which could emit a single line in an outgoing packet for all 10,000 increments. This type of optimization is less effective with different choices of worker selection.
- [ ] Benchmark metric throughput against [Statix](https://github.com/lexmag/statix)